### PR TITLE
chore: AI agents push their branch only when they produced changes

### DIFF
--- a/.github/workflows/ai-convention-agent.yml
+++ b/.github/workflows/ai-convention-agent.yml
@@ -106,14 +106,16 @@ jobs:
           ref: master
           fetch-depth: 0
 
-      - name: Switch to agent branch (create if ai-only mode)
+      - name: Switch to agent branch (create locally when auto-format pushed nothing)
+        # The branch exists on the remote only when auto-format found something to commit.
+        # Otherwise it is recreated local-only: the push in "Detect and commit changes"
+        # creates it remotely, so a run producing no changes leaves no branch behind.
         run: |
           BRANCH="ai-quality-agent/nightly-${{ github.run_id }}"
           if git fetch origin "$BRANCH" 2>/dev/null; then
             git checkout "$BRANCH"
           else
             git checkout -b "$BRANCH"
-            git push origin "$BRANCH"
           fi
 
       - name: Set up JDK 25

--- a/.github/workflows/ai-coverage-agent.yml
+++ b/.github/workflows/ai-coverage-agent.yml
@@ -52,11 +52,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create and push agent branch
-        run: |
-          BRANCH="ai-coverage-agent/weekly-${{ github.run_id }}"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+      - name: Create agent branch (local only — pushed only if changes are made)
+        # The remote branch is created by the first push in "Detect and commit changes",
+        # so a run where Claude finds nothing leaves no branch behind on the remote.
+        run: git checkout -b "ai-coverage-agent/weekly-${{ github.run_id }}"
 
       - name: Run tests and generate JaCoCo coverage reports
         # Use -Pnostyle to skip style checks; exclude benchmarks as they are not unit tests.

--- a/.github/workflows/ai-performance-agent.yml
+++ b/.github/workflows/ai-performance-agent.yml
@@ -52,11 +52,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create and push agent branch
-        run: |
-          BRANCH="ai-performance-agent/weekly-${{ github.run_id }}"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+      - name: Create agent branch (local only — pushed only if changes are made)
+        # The remote branch is created by the first push in "Detect and commit changes",
+        # so a run where Claude finds nothing leaves no branch behind on the remote.
+        run: git checkout -b "ai-performance-agent/weekly-${{ github.run_id }}"
 
       - name: Compile project (gives Claude full context)
         run: mvn package -Pfast --file pom.xml --batch-mode -q

--- a/.github/workflows/ai-refactoring-agent.yml
+++ b/.github/workflows/ai-refactoring-agent.yml
@@ -43,11 +43,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create and push agent branch
-        run: |
-          BRANCH="ai-refactoring-agent/nightly-${{ github.run_id }}"
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+      - name: Create agent branch (local only — pushed only if changes are made)
+        # The remote branch is created by the first push in "Detect and commit changes",
+        # so a run where Claude finds nothing leaves no branch behind on the remote.
+        run: git checkout -b "ai-refactoring-agent/nightly-${{ github.run_id }}"
 
       - name: Compile project (gives Claude full symbol context)
         run: mvn package -Pfast --file pom.xml --batch-mode -q


### PR DESCRIPTION
## Summary

The four AI agents pushed their working branch to the remote **before** invoking Claude:

```yaml
- name: Create and push agent branch
  run: |
    BRANCH="ai-performance-agent/weekly-${{ github.run_id }}"
    git checkout -b "$BRANCH"
    git push origin "$BRANCH"   # ← unconditional, no changes yet
```

Every run where the agent found nothing therefore left an empty branch on the remote, with no
PR attached and nothing to clean it up (`deleteBranchOnMerge` only fires on a merge). 63 of the
92 agent branches on `origin` had zero commits of their own.

The branch is now created locally only; the `git push` already present in *Detect and commit
changes* creates it remotely on first commit, so a no-op run leaves nothing behind.

## Changes

- `ai-performance-agent.yml`, `ai-refactoring-agent.yml`, `ai-coverage-agent.yml` — drop the eager `git push` from the branch-creation step.
- `ai-convention-agent.yml` — same fix in the `ai-review` job, whose fallback arm (taken whenever `auto-format` found nothing to commit, i.e. most scheduled runs) also pushed unconditionally. Job 1 was already correct.

Dead branches were swept separately: 74 deleted (63 empty + 11 whose verification step failed, so
they were never proposed as a PR), leaving `origin` at 34 branches. All 18 agent branches backing
an open PR were kept.

## Review checklist

- [ ] `git push origin HEAD` in *Detect and commit changes* creates the remote branch (no upstream needed)
- [ ] `open-pr` only runs when `changed == 'true'`, so `--head "$BRANCH"` always resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)