### PR TITLE
chore: let agent and fixer PRs run their required checks

### DIFF
--- a/.github/workflows/ai-convention-agent.yml
+++ b/.github/workflows/ai-convention-agent.yml
@@ -84,7 +84,9 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git add -A
-            git commit -m "chore: auto-format via Spotless and Prettier [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the required
+            # status checks only ever run if the pull_request event is allowed to fire.
+            git commit -m "chore: auto-format via Spotless and Prettier"
             git push origin "$BRANCH"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -221,7 +223,9 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git add -A
-            git commit -m "chore: AI code quality improvements via Claude [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the required
+            # status checks only ever run if the pull_request event is allowed to fire.
+            git commit -m "chore: AI code quality improvements via Claude"
             git push origin HEAD
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ai-coverage-agent.yml
+++ b/.github/workflows/ai-coverage-agent.yml
@@ -104,7 +104,9 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git add -A
-            git commit -m "test: AI coverage improvements via Claude [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the required
+            # status checks only ever run if the pull_request event is allowed to fire.
+            git commit -m "test: AI coverage improvements via Claude"
             git push origin HEAD
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ai-performance-agent.yml
+++ b/.github/workflows/ai-performance-agent.yml
@@ -97,7 +97,9 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git add -A
-            git commit -m "chore: AI performance improvements via Claude [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the required
+            # status checks only ever run if the pull_request event is allowed to fire.
+            git commit -m "chore: AI performance improvements via Claude"
             git push origin HEAD
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ai-refactoring-agent.yml
+++ b/.github/workflows/ai-refactoring-agent.yml
@@ -91,7 +91,9 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git add -A
-            git commit -m "chore: AI refactoring towards helper methods via Claude [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the required
+            # status checks only ever run if the pull_request event is allowed to fire.
+            git commit -m "chore: AI refactoring towards helper methods via Claude"
             git push origin HEAD
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ai-renovate-fixer.yml
+++ b/.github/workflows/ai-renovate-fixer.yml
@@ -140,6 +140,8 @@ jobs:
             echo "No changes produced — violations may require manual attention."
           else
             git add -A
-            git commit -m "fix: resolve static-analysis violations introduced by Renovate update [skip ci]"
+            # No [skip ci] marker: this commit becomes the PR head, and the Renovate PR
+            # stays blocked unless its required checks re-run against the repaired tree.
+            git commit -m "fix: resolve static-analysis violations introduced by Renovate update"
             git push
           fi


### PR DESCRIPTION
## Summary

All five AI workflows committed their work with a `[skip ci]` marker:

```bash
git commit -m "chore: AI code quality improvements via Claude [skip ci]"
```

GitHub Actions skips `push` and `pull_request` runs when the head commit message
carries that marker. Since this commit *becomes the PR head*, the marker never
expires — the PR produces **zero Actions runs, ever**.

The `master` ruleset requires 8 status checks, so those PRs can never satisfy them
and sit permanently `BLOCKED`. Measured across the 10 open agent PRs: 9 have zero
Actions runs and one check (`Cleanthat`, a GitHub App, hence unaffected by the marker).

The marker bought nothing: every CI workflow already scopes its push trigger to master,

```yaml
on:
  push:
    branches: [ "master" ]
  pull_request:
    branches: [ "master" ]
```

so a push to `ai-quality-agent/...` never triggered CI in the first place. The only
thing `[skip ci]` suppressed was the `pull_request` event the PR depends on.

## Changes

Dropped the marker from all six commit sites, each with a comment so it is not
reintroduced:

- `ai-convention-agent.yml` (auto-format + ai-review jobs)
- `ai-coverage-agent.yml`, `ai-performance-agent.yml`, `ai-refactoring-agent.yml`
- `ai-renovate-fixer.yml` — same defect, worse effect: the fix commit silenced the
  very checks meant to prove the repair worked, leaving the Renovate PR blocked.

The 10 open agent branches are being re-pushed with corrected commit messages so
they pick up their first real CI run.

## Review checklist

- [ ] No CI workflow triggers on push to a non-master branch (so removing the marker adds no duplicate runs)
- [ ] Agent PRs now produce check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)